### PR TITLE
feat: 플랜 및 마이페이지 화면 구성

### DIFF
--- a/app/mypage/page.tsx
+++ b/app/mypage/page.tsx
@@ -1,0 +1,88 @@
+import { redirect } from "next/navigation";
+
+import { AccessRequestCard } from "@/components/access-request-card";
+import { AppShell } from "@/components/app-shell";
+import { getAccessState } from "@/lib/auth";
+import { formatDurationLabel } from "@/lib/display";
+import { getRoleFeatures } from "@/lib/allowlist";
+import { getDailyUsageSummary } from "@/lib/usage";
+
+export default async function MyPage() {
+  const access = await getAccessState();
+
+  if (!access.session || !access.email) {
+    redirect("/?notice=login-required");
+  }
+
+  const features = getRoleFeatures(access.role);
+  const usageSummary = await getDailyUsageSummary(access.email, access.role);
+  const statusText = {
+    approved: "승인 완료",
+    not_requested: "승인 필요",
+    pending: "검토 중",
+  }[access.membershipStatus];
+
+  return (
+    <AppShell
+      access={access}
+      currentPath="/mypage"
+      description="현재 로그인한 계정과 플랜 정보, 승인 상태, 오늘 사용량을 확인할 수 있는 계정 페이지입니다."
+      title="마이페이지"
+      usageSummary={usageSummary}
+    >
+      <div className="grid gap-6 lg:grid-cols-[1.15fr_0.85fr]">
+        <div className="grid gap-4">
+          <div className="rounded-[1.5rem] border border-border bg-white/92 p-6">
+            <p className="text-xs font-semibold tracking-[0.16em] text-accent">계정 정보</p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-2">
+              <div>
+                <p className="text-sm text-muted">이름</p>
+                <p className="text-lg font-semibold text-foreground">{access.name ?? "이름 미등록"}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted">이메일</p>
+                <p className="text-lg font-semibold text-foreground">{access.email}</p>
+              </div>
+            </div>
+          </div>
+
+          <div className="rounded-[1.5rem] border border-border bg-white/92 p-6">
+            <p className="text-xs font-semibold tracking-[0.16em] text-accent">이용 정보</p>
+            <div className="mt-4 grid gap-4 sm:grid-cols-4">
+              <div>
+                <p className="text-sm text-muted">상태</p>
+                <p className="text-lg font-semibold text-foreground">{statusText}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted">플랜</p>
+                <p className="text-lg font-semibold text-foreground">{features.label}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted">최대 길이</p>
+                <p className="text-lg font-semibold text-foreground">
+                  {formatDurationLabel(features.maxMediaDurationSeconds)}
+                </p>
+              </div>
+              <div>
+                <p className="text-sm text-muted">오늘 남은 횟수</p>
+                <p className="text-lg font-semibold text-foreground">
+                  {access.canUseStudio ? `${usageSummary.remaining}회` : "승인 후 사용"}
+                </p>
+              </div>
+            </div>
+            <p className="mt-4 text-sm leading-6 text-muted">{features.description}</p>
+          </div>
+        </div>
+
+        <AccessRequestCard
+          canUseStudio={access.canUseStudio}
+          currentPlan={access.role}
+          currentPlanLabel={features.label}
+          membershipStatus={access.membershipStatus}
+          requestedPlan={access.requestedPlan}
+          requestedPlanLabel={access.requestedPlan ? getRoleFeatures(access.requestedPlan).label : null}
+        />
+      </div>
+    </AppShell>
+  );
+}

--- a/app/plans/page.tsx
+++ b/app/plans/page.tsx
@@ -1,0 +1,70 @@
+import { redirect } from "next/navigation";
+
+import { AppShell } from "@/components/app-shell";
+import { PlanRequestButton } from "@/components/plan-request-button";
+import { getAccessState } from "@/lib/auth";
+import { accessRoles, getRoleFeatures } from "@/lib/allowlist";
+import { formatDurationLabel } from "@/lib/display";
+import { getDailyUsageSummary } from "@/lib/usage";
+
+export default async function PlansPage() {
+  const access = await getAccessState();
+
+  if (!access.session || !access.email) {
+    redirect("/?notice=login-required");
+  }
+
+  const usageSummary = await getDailyUsageSummary(access.email, access.role);
+
+  return (
+    <AppShell
+      access={access}
+      currentPath="/plans"
+      description="플랜별 하루 사용 횟수와 업로드 가능한 파일 길이를 비교하고, 필요한 경우 이용 신청이나 업그레이드 요청을 남길 수 있습니다."
+      title="플랜"
+      usageSummary={usageSummary}
+    >
+      <div className="grid gap-4 lg:grid-cols-4">
+        {accessRoles.map((role) => {
+          const features = getRoleFeatures(role);
+          const isCurrent = access.membershipStatus === "approved" && access.role === role;
+
+          return (
+            <div
+              key={role}
+              className={`rounded-[1.75rem] border p-6 shadow-[0_16px_35px_rgba(31,38,52,0.05)] ${
+                isCurrent ? "border-[#f1c8b5] bg-[#fff7f1]" : "border-border bg-white/92"
+              }`}
+            >
+              <p className="text-xs font-semibold tracking-[0.16em] text-accent">{features.label}</p>
+              <h2 className="mt-3 text-3xl font-semibold tracking-tight text-foreground">
+                {formatDurationLabel(features.maxMediaDurationSeconds)}
+              </h2>
+              <p className="mt-2 text-sm leading-6 text-muted">{features.description}</p>
+
+              <div className="mt-5 space-y-3 rounded-[1.25rem] bg-[#fffdfa] px-4 py-4 text-sm text-muted">
+                <p>하루 더빙 횟수: {features.dailyGenerationLimit}회</p>
+                <p>최대 파일 길이: {formatDurationLabel(features.maxMediaDurationSeconds)}</p>
+                <p>
+                  {role === "free"
+                    ? "승인 후 바로 시작할 수 있는 기본 플랜"
+                    : "더 긴 파일과 더 많은 생성 횟수가 필요한 경우 추천"}
+                </p>
+              </div>
+
+              <div className="mt-5">
+                <PlanRequestButton
+                  currentRole={access.role}
+                  hasStudioAccess={access.canUseStudio}
+                  membershipStatus={access.membershipStatus}
+                  requestedPlan={access.requestedPlan}
+                  targetPlan={role}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </AppShell>
+  );
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "skipLibCheck": true,
     "strict": true,
     "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "module": "esnext",
     "moduleResolution": "bundler",


### PR DESCRIPTION
## 요약
readvox의 사용자 화면 흐름을 정리
로그인 전 랜딩 페이지부터 로그인 후 대시보드, 스튜디오, 플랜, 마이페이지까지 과제 흐름에 맞춰 화면 구조와 문구를 한국어 기준으로 정리했습니다.

## 변경 내용
- readvox 랜딩 페이지 구성
- 대시보드, 스튜디오, 플랜, 마이페이지 화면 구성
- 버튼/상태 카드/사용량 표시 등 UI 정리
- 사용자 노출 문구 한국어화

## 검증
- [x] npm run lint
- [x] npm run build
- [x] 로그인 전 랜딩 흐름 확인
- [x] 플랜/마이페이지 상태 표시 확인

## 제외한 내용
- 인증/allowlist 로직 자체 구현
- AI 더빙 파이프라인 서버 로직
- 제출 문서 최종 정리

Closes #5
